### PR TITLE
fix: Out of sync fix

### DIFF
--- a/server/src/notifications.rs
+++ b/server/src/notifications.rs
@@ -187,10 +187,6 @@ async fn unregister_device(
             .registration_tokens
             .retain(|token| token.token != registration_token.token);
 
-        if notification_key.registration_tokens.is_empty() {
-            user_metadata.notification_key = None;
-        }
-
         let meta_raw = serde_json::to_vec(&user_metadata).map_err(Error::Deser)?;
         let _replaced: bool = conn.hset(user, METADATA_FIELD, &meta_raw).await?;
 


### PR DESCRIPTION
- When the notification on local storage is enabled but if the user disables notification from the browser. This causes the backend to go out of sync with the frontend.
- Because as soon as the notificaition on browser is disabled, the notification key for that device gets expired. The backend still points to the old stale notification key.
- This PR makes it more robust and forces it to recover if not found


```mermaid
flowchart LR
  subgraph RegisterDevice
    A[Start] --> B[Fetch user metadata]
    B --> C{notification_key exists?}

    C -->|Yes| D[Find old token]
    D --> E{old token?}
    E -->|Yes| F[FCM Remove old token]
    F --> G[FCM Add new token]
    E -->|No| G

    C -->|No| H[FCM Create new key]

    G --> I[Handle Add response]
    H --> J[Handle Create response]

    I -->|OK| K[Use returned key]
    I -->|Err 'not found'| H
    J -->|OK| K
    J -->|Err 'exists'| L[Parse existing key from error]
    L --> M[FCM Add using existing key]
    M --> K

    K --> N[Update Redis metadata with key & tokens]
    N --> O[Done]
  end

  subgraph UnregisterDevice
    A2[Start] --> B2[Fetch user metadata]
    B2 --> C2{notification_key exists?}
    C2 -->|No| X[Done: No action needed]
    C2 -->|Yes| D2[Find token to delete]
    D2 --> E2{token found?}
    E2 -->|No| Y[Done: No action needed]
    E2 -->|Yes| F2[FCM Remove token]
    F2 --> G2{Any tokens left?}
    G2 -->|Yes| H2[Update Redis with remaining tokens]
    G2 -->|No| I2[Keep notification_key in Redis]
    H2 --> J2[Done]
    I2 --> J2
  end

  subgraph OldFlow["Old Problematic Flow"]
    OF1["Edge-case re-register
(browser permission revoked but toggle=true)"]
    OF2["Backend fetches Redis metadata
meta.notification_key exists"]
    OF3["Backend builds FCM Add request
get_add_request_body(key_name, old_key, token)"]
    OF4["FCM API → Error: notification_key not found
(key was deleted from FCM in prior unregister)"]
    OF5["No retry logic → propagate error
registration fails"]
    OF1 --> OF2 --> OF3 --> OF4 --> OF5
  end

  subgraph FixedFlow["Current Fixed Flow with Recovery"]
    FF1["Edge-case re-register
(browser permission revoked but toggle=true)"]
    FF2["Backend fetches Redis metadata
meta.notification_key exists"]
    FF3["Backend builds FCM Add request
get_add_request_body(key_name, old_key, token)"]
    FF4["FCM API → Error: notification_key not found"]
    FF5["Fallback → build FCM Create request
get_create_request_body(key_name, token)"]
    FF6["Call FCM Create → success
returns new notification_key"]
    FF7["Update Redis metadata
set meta.notification_key.key & tokens"]
    FF8["Return success → registration succeeds"]
    FF1 --> FF2 --> FF3 --> FF4 --> FF5 --> FF6 --> FF7 --> FF8
  end

```