### PR TITLE
feat(notifications): add is_migrated field to UserMetadata and update…

### DIFF
--- a/server/src/notifications/mocks.rs
+++ b/server/src/notifications/mocks.rs
@@ -43,6 +43,7 @@ impl From<MockUserMetadata> for ActualUserMetadata {
             }),
             user_name: mock.user_name,
             notification_key: mock.notification_key,
+            is_migrated: false,
         }
     }
 }

--- a/server/src/notifications/mod.rs
+++ b/server/src/notifications/mod.rs
@@ -86,6 +86,11 @@ pub async fn register_device_impl<
         }
     };
 
+    if !user_metadata.is_migrated {
+        user_metadata.notification_key = None;
+        user_metadata.is_migrated = true;
+    }
+
     let maybe_notification_key_ref = user_metadata.notification_key.as_ref();
     let original_key_in_redis: Option<String> = maybe_notification_key_ref.map(|nk| nk.key.clone());
 

--- a/server/src/notifications/tests.rs
+++ b/server/src/notifications/tests.rs
@@ -31,6 +31,7 @@ mod tests {
             user_canister_id: user_id.parse().expect("Test user_id not a valid principal"),
             user_name: format!("user_{}", user_id),
             notification_key,
+            is_migrated: false,
         }
     }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -38,6 +38,9 @@ pub struct UserMetadata {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notification_key: Option<NotificationKey>,
+
+    #[serde(default)]
+    pub is_migrated: bool,
 }
 
 impl TryFrom<UserMetadata> for Message {


### PR DESCRIPTION
fixes https://github.com/dolr-ai/product-roadmap/issues/578

… related logic

- Introduced `is_migrated` field in `UserMetadata` to track migration status.
- Updated `MockUserMetadata` and test cases to initialize `is_migrated` to false.
- Modified device registration logic to set `notification_key` to None and mark as migrated when not previously migrated.