### PR TITLE
fix: open-api explorer endpoint fix

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,7 +22,7 @@ primary_region = 'sin'
 
 
 [[vm]]
-  memory = '256mb'
+  memory = '512mb'
   cpu_kind = 'shared'
   cpus = 1
 

--- a/server/src/api/handlers.rs
+++ b/server/src/api/handlers.rs
@@ -2,6 +2,7 @@ use axum::{
     extract::{Path, State},
     http::HeaderMap,
     Json,
+    response::IntoResponse
 };
 use candid::Principal;
 use std::sync::Arc;
@@ -219,4 +220,9 @@ pub async fn get_canister_to_principal_bulk(
     let result =
         get_canister_to_principal_bulk_impl(&state.redis, req, CANISTER_TO_PRINCIPAL_KEY).await?;
     Ok(Json(Ok(result)))
+}
+
+/// Health check endpoint
+pub async fn healthz() -> axum::response::Response {
+    Json(serde_json::json!({"status": "ok"})).into_response()
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -106,6 +106,8 @@ async fn main_impl() -> Result<()> {
         )
         // OpenAPI/Swagger UI routes
         .route("/explorer/{*tail}", get(services::openapi::get_swagger))
+        .route("/explorer/", get(services::openapi::get_swagger_root))
+        .route("/healthz", get(api::handlers::healthz))
         // Add shared state
         .with_state(state)
         // Add middleware layers (applied in reverse order)


### PR DESCRIPTION
- fixed explorer endpoint to work as before after axum  migration.
- add healthz endpoint.
- increased memory size to 512mb in fly.toml , as discussed.