### PR TITLE
fix : high memory consumption

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -22,7 +22,7 @@ primary_region = 'sin'
 
 
 [[vm]]
-  memory = '512mb'
+  memory = '256mb'
   cpu_kind = 'shared'
   cpus = 1
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -154,10 +154,7 @@ fn main() {
                     .into(),
             ),
             send_default_pii: true,
-            traces_sample_rate: std::env::var("SENTRY_TRACES_SAMPLE_RATE")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0.01), //lower sampling for lower data accumulation.
+            traces_sample_rate: 0.01, //lower sampling for lower data accumulation.
             attach_stacktrace: true,
             auto_session_tracking: true,
             max_breadcrumbs: 100, // Store more breadcrumbs for better context

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -24,7 +24,9 @@ use axum::{
     Router,
 };
 use config::AppConfig;
+use sentry_tower::{NewSentryLayer, SentryHttpLayer};
 use state::AppState;
+use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
 use utils::error::*;
 
@@ -46,6 +48,11 @@ async fn main_impl() -> Result<()> {
     let conf = AppConfig::load()?;
 
     let state = Arc::new(AppState::new(&conf).await?);
+
+    // Sentry middleware
+    let sentry_tower_layer = ServiceBuilder::new()
+        .layer(NewSentryLayer::new_from_top())
+        .layer(SentryHttpLayer::with_transaction());
 
     // Build the application router with all routes defined here
     let app = Router::new()
@@ -98,7 +105,10 @@ async fn main_impl() -> Result<()> {
         )
         // Signup routes
         .route("/email/{user_principal}", post(signup::set_user_email))
-        .route("/signup/{user_principal}", post(signup::set_signup_datetime))
+        .route(
+            "/signup/{user_principal}",
+            post(signup::set_signup_datetime),
+        )
         // Admin routes
         .route(
             "/admin/populate-canister-index",
@@ -108,12 +118,11 @@ async fn main_impl() -> Result<()> {
         .route("/explorer/{*tail}", get(services::openapi::get_swagger))
         .route("/explorer/", get(services::openapi::get_swagger_root))
         .route("/healthz", get(api::handlers::healthz))
+        .layer(CorsLayer::permissive())
+        // Add sentry middleware layer
+        .layer(sentry_tower_layer)
         // Add shared state
-        .with_state(state)
-        // Add middleware layers (applied in reverse order)
-        .layer(sentry_tower::NewSentryLayer::new_from_top())
-        .layer(sentry_tower::SentryHttpLayer::with_transaction())
-        .layer(CorsLayer::permissive());
+        .with_state(state.clone());
 
     let listener = tokio::net::TcpListener::bind(conf.bind_address)
         .await
@@ -126,8 +135,7 @@ async fn main_impl() -> Result<()> {
     Ok(())
 }
 
-fn main() -> Result<()>{
-
+fn main() {
     // Initialize Sentry with enhanced configuration
     let _guard = sentry::init((
         "https://ca9ac4e37832428f5804817e010068dd@apm.yral.com/6",
@@ -149,7 +157,7 @@ fn main() -> Result<()>{
             traces_sample_rate: std::env::var("SENTRY_TRACES_SAMPLE_RATE")
                 .ok()
                 .and_then(|s| s.parse().ok())
-                .unwrap_or(0.5),
+                .unwrap_or(0.01), //lower sampling for lower data accumulation.
             attach_stacktrace: true,
             auto_session_tracking: true,
             max_breadcrumbs: 100, // Store more breadcrumbs for better context
@@ -162,9 +170,11 @@ fn main() -> Result<()>{
 
     log::info!("Sentry initialized successfully");
 
-    tokio::runtime::Builder::new_multi_thread().enable_all().build()?.block_on(
-        async {
-            main_impl().await.map_err(|e| Error::from(e))
-        }
-    )
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            main_impl().await.unwrap();
+        });
 }

--- a/server/src/notifications/mod.rs
+++ b/server/src/notifications/mod.rs
@@ -66,7 +66,7 @@ pub async fn register_device(
     register_device_impl(
         firebase_service,
         redis_service,
-        user_principal.to_text(),
+        user_principal,
         Json(req),
     )
     .await
@@ -333,7 +333,7 @@ pub async fn unregister_device(
     unregister_device_impl(
         firebase_service,
         redis_service,
-        user_principal.to_text(),
+        user_principal,
         Json(req),
     )
     .await
@@ -483,7 +483,7 @@ pub async fn send_notification(
         Some(&headers),
         firebase_service,
         redis_service,
-        user_principal.to_text(),
+        user_principal,
         Json(req),
     )
     .await

--- a/server/src/notifications/traits.rs
+++ b/server/src/notifications/traits.rs
@@ -70,6 +70,16 @@ impl UserPrincipal for Path<Principal> {
     }
 }
 
+impl UserPrincipal for Principal {
+    fn to_text(&self) -> String {
+        self.to_text()
+    }
+
+    fn as_principal(&self) -> Option<Principal> {
+        Some(*self)
+    }
+}
+
 impl UserPrincipal for String {
     fn to_text(&self) -> String {
         self.clone()


### PR DESCRIPTION
- Rearranged layers.
- tweak in sentry config.
- - reduced trace sampling rate to 0.01 from 0.5. (0.5 was sampling 50% of all the trace logs, we kept breadcrumbs to 100 for better context if any error arises.)
- small fix in trait impl in notification handler.


above changes resulted into almost constant memory graph as before and stopped server from crashing. 
can check memory graph here :  https://fly-metrics.net/d/fly-instance/fly-instance?from=now-3h&orgId=340601&to=now&var-app=pr-67-dolr-ai-yral-metadata&var-instance=d890deebe95718

cpu utilisation : https://fly-metrics.net/d/fly-instance/fly-instance?from=now-3h&orgId=340601&to=now&var-app=pr-67-dolr-ai-yral-metadata&var-instance=d890deebe95718